### PR TITLE
metadata.xml

### DIFF
--- a/en/metadata.xml
+++ b/en/metadata.xml
@@ -1,0 +1,3 @@
+<dc:title>The Little Redis Book</dc:title>
+<dc:creator opf:file-as="Seguin, Karl" opf:role="aut">Karl Seguin</dc:creator>
+<dc:contributor opf:file-as="Neal, Perry" opf:role="edt">Perry Neal</dc:contributor>


### PR DESCRIPTION
Adding metadata.xml as per http://johnmacfarlane.net/pandoc/README.html 

Using the following command, modified from the one at http://news.ycombinator.com/item?id=3502033 we can generate an ePub file with proper attribution (title, author and creator):

pandoc -f markdown -t epub --epub-metadata=en/metadata.xml --template=template/xetex.template -V paper=$paper -V hmargin=$hmargin -V vmargin=$vmargin -V mainfont="$mainfont" -V sansfont="$sansfont" -V monofont="$monofont" -V geometry=$geometry -V columns=$columns -V fontsize=$fontsize -V nohyphenation=$nohyphenation en/redis.md -o redis.epub
